### PR TITLE
chore(release): 1.1.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.1](https://github.com/newjersey/business.nj.gov/compare/v1.1.0...v1.1.1) (2021-11-11)
+
+
+### Bug Fixes
+
+* **deps:** upgrade dependencies to the latest version ([8ace195](https://github.com/newjersey/business.nj.gov/commit/8ace195172181e196d7d91416871d1e06dfe7d69))
+
 # [1.1.0](https://github.com/newjersey/business.nj.gov/compare/v1.0.1...v1.1.0) (2021-11-11)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "This is the development repository for the work-in-progress business dashboard from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
## [1.1.1](https://github.com/newjersey/business.nj.gov/compare/v1.1.0...v1.1.1) (2021-11-11)

### Bug Fixes

* **deps:** upgrade dependencies to the latest version ([8ace195](https://github.com/newjersey/business.nj.gov/commit/8ace195172181e196d7d91416871d1e06dfe7d69))
